### PR TITLE
feat(color): add no color mode

### DIFF
--- a/kict.py
+++ b/kict.py
@@ -558,8 +558,15 @@ if __name__ == "__main__":
                         action="store_true",
                         default=False,
                         help="Debug mode")
+    parser.add_argument('-t', '--text', # 去掉Ascii 颜色字符
+                        action="store_true",
+                        default=False,
+                        help="Show plain text, without ascii color chars.")
 
     options = parser.parse_args()
+
+    if options.text:
+        _c = lambda s, color='none': s
 
     if options.daysay:
         try:


### PR DESCRIPTION
对于neovim中调用外部命令，这类不支持ascii color的场景，支持通过命令行参数去掉ascii color字符串。
![image](https://user-images.githubusercontent.com/2120685/74313482-bab08400-4dae-11ea-9350-33556107d6cc.png)
